### PR TITLE
Update functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -98,7 +98,7 @@ add_action( 'after_setup_theme', 'mog_setup' );
  */
 function mog_register_custom_background() {
 	$args = array(
-		'default-color' => 'ffffff',
+		'default-color' => 'F5F5F5',
 		'default-image' => '',
 	);
 


### PR DESCRIPTION
Since upgrading to WordPress 3.9, it's impossible to get a white background to stick with Mog.

If you choose any other color than white, it will show up.
If you choose white, it shows up as #F5F5F5

I believe it's because in functions.php the default color is set to white (FFFFFF)...So if you choose white, it won't trigger the custom background color. 

The result is it defaults to what is in styles.css which is not actually white, but F5F5F5.

In this edit, I've made the default background color in functions.php match what is in styles.css
